### PR TITLE
Update Job removal to make more efficient use of redis

### DIFF
--- a/src/job.js
+++ b/src/job.js
@@ -275,7 +275,7 @@ Job.prototype.remove = function(cb) {
   }else if(r.queue.length > 1){
     var args = r.queue[1];
     var cmd = args.shift();
-    this.redis[cmd].apply(this.redis, args);
+    this.redis[cmd](args, cb);
   }
 };
 


### PR DESCRIPTION
If the MULTI is only going to execute a single command, extract that command and run it directly rather than bothering with the overhead of MULTI and EXEC and the locking that comes with it. And if it's empty, don't do anything at all.
